### PR TITLE
Update limereport.pro

### DIFF
--- a/limereport/limereport.pro
+++ b/limereport/limereport.pro
@@ -27,7 +27,7 @@ unix {
     DESTDIR  = $${BUILD_DIR}/$${BUILD_TYPE}/lib
     #QMAKE_POST_LINK += mkdir -p $$quote($${DESTDIR}/include) $$escape_expand(\\n\\t)
     for(FILE,EXTRA_FILES){
-        QMAKE_POST_LINK += $$QMAKE_COPY $$quote($$FILE) $$quote($${DEST_INCLUDE_DIR}/include/) $$escape_expand(\\n\\t)
+        QMAKE_POST_LINK += $$QMAKE_COPY $$quote($$FILE) $$quote($${DEST_INCLUDE_DIR}) $$escape_expand(\\n\\t)
     }
     QMAKE_POST_LINK += $(COPY_DIR) $$quote($${DEST_INCLUDE_DIR}*) $$quote($${DEST_DIR})
 }


### PR DESCRIPTION
mv -f liblimereport.so.1.0 ../build/5.6.0/release/lib/ 

cp -f /home/travis/build/newsages/LimeReport/limereport/lrglobal.cpp /home/travis/build/newsages/LimeReport/include//include/ 

cp: cannot create regular file ‘/home/travis/build/newsages/LimeReport/include//include/’: Not a directory